### PR TITLE
Improve parsing speed by ~4x

### DIFF
--- a/Sources/BlurHashViews/BlurHashDecoding.swift
+++ b/Sources/BlurHashViews/BlurHashDecoding.swift
@@ -50,44 +50,132 @@ fileprivate func sRGBToLinear<Type: BinaryInteger>(_ value: Type) -> Float {
 	else { return pow((v + 0.055) / 1.055, 2.4) }
 }
 
-fileprivate let encodeCharacters: [String] = {
-	return "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz#$%*+,-.:;=?@[]^_{|}~".map { String($0) }
-}()
+internal struct ParsingError: Error {}
 
-fileprivate let decodeCharacters: [String: Int] = {
-	var dict: [String: Int] = [:]
-	for (index, character) in encodeCharacters.enumerated() {
-		dict[character] = index
-	}
-	return dict
-}()
+/// Decode the first numCharacters of the substring using custom base 83 format.
+///
+/// The substring is advanced to no longer contain the decoded characters if successful.
+internal func decode83(numCharacters: Int, from input: inout Substring.UTF8View) throws -> Int {
+	guard input.count >= numCharacters else { throw ParsingError() }
 
-internal extension String {
-	func decode83() -> Int {
-		var value: Int = 0
-		for character in self {
-			if let digit = decodeCharacters[String(character)] {
-				value = value * 83 + digit
-			}
+	var value: Int = 0
+	for _ in 0 ..< numCharacters {
+		if let digit = try? input.popFirst()?.decode83() {
+			value = value * 83 + digit
 		}
+	}
+
+	return value
+}
+
+private extension UInt8 {
+	func decode83() throws -> Int {
+		let index = Int(self) - 35
+		guard lookupTable.indices.contains(index)  else { throw ParsingError() }
+
+		let value = lookupTable[index]
+		guard value != -1 else { throw ParsingError() }
+
 		return value
 	}
 }
 
-internal extension String {
-	subscript (offset: Int) -> Character {
-		return self[index(startIndex, offsetBy: offset)]
-	}
-	
-	subscript (bounds: CountableClosedRange<Int>) -> Substring {
-		let start = index(startIndex, offsetBy: bounds.lowerBound)
-		let end = index(startIndex, offsetBy: bounds.upperBound)
-		return self[start...end]
-	}
-	
-	subscript (bounds: CountableRange<Int>) -> Substring {
-		let start = index(startIndex, offsetBy: bounds.lowerBound)
-		let end = index(startIndex, offsetBy: bounds.upperBound)
-		return self[start..<end]
-	}
-}
+/// Lookup table to find the Int representation for a character. The indices of the table are the
+/// character ASCII values minus the ASCII value of the lowest character (35) so that the lowest
+/// character is at index 0. The value in the table is that character's position within the encoding
+/// character set:
+/// 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz#$%*+,-.:;=?@[]^_{|}~
+private let lookupTable = [
+	62, // #
+	63, // $
+	64, // %
+	-1,
+	-1,
+	-1,
+	-1,
+	65, // *
+	66, // +
+	67, // ,
+	68, // -
+	69, // .
+	-1,
+	0, // 0
+	1, // 1
+	2, // 2
+	3, // 3
+	4, // 4
+	5, // 5
+	6, // 6
+	7, // 7
+	8, // 8
+	9, // 9
+	70, // :
+	71, // ;
+	-1,
+	72, // =
+	-1,
+	73, // ?
+	74, // @
+	10, // A
+	11, // B
+	12, // C
+	13, // D
+	14, // E
+	15, // F
+	16, // G
+	17, // H
+	18, // I
+	19, // J
+	20, // K
+	21, // L
+	22, // M
+	23, // N
+	24, // O
+	25, // P
+	26, // Q
+	27, // R
+	28, // S
+	29, // T
+	30, // U
+	31, // V
+	32, // W
+	33, // X
+	34, // Y
+	35, // Z
+	75, // [
+	-1,
+	76, // ]
+	77, // ^
+	78, // _
+	-1,
+	36, // a
+	37, // b
+	38, // c
+	39, // d
+	40, // e
+	41, // f
+	42, // g
+	43, // h
+	44, // i
+	45, // j
+	46, // k
+	47, // l
+	48, // m
+	49, // n
+	50, // o
+	51, // p
+	52, // q
+	53, // r
+	54, // s
+	55, // t
+	56, // u
+	57, // v
+	58, // w
+	59, // x
+	60, // y
+	61, // z
+	79, // {
+	80, // |
+	81, // }
+	82, // ~
+]

--- a/Sources/BlurHashViews/Color+averageFromBlurHash.swift
+++ b/Sources/BlurHashViews/Color+averageFromBlurHash.swift
@@ -12,8 +12,9 @@ public extension Color {
 	///
 	/// Returns `nil` if the BlurHash string is invalid.
 	init?(averageFromBlurHash blurHash: String) {
-		guard blurHash.count >= 6 else { return nil }
-		let value = String(blurHash[2 ..< 6]).decode83()
+		var substring = blurHash.utf8.dropFirst(2)
+		guard let value = try? decode83(numCharacters: 4, from: &substring) else { return nil }
+
 		let rgb = decodeDC(value)
 		self.init(.sRGBLinear, red: Double(rgb.x), green: Double(rgb.y), blue: Double(rgb.z))
 	}


### PR DESCRIPTION
Moving back and forth between `String` and `Character` is pretty slow, as well as repeatedly computing `String` offsets using the custom subscripts.

Since all of the valid characters consume a single UTF8 code unit (by design) we can safely iterate on the string's `UTF8View`.

This approach is adapted from https://github.com/pointfreeco/swift-parsing/

Using [swift-benchmark](https://github.com/google/swift-benchmark) this change results in about a 4x speedup of the `Mesh` initializer.

```
name     time        std        iterations
------------------------------------------
Original 6208.000 ns ±   6.76 %     220336
Revised  1541.000 ns ±  14.90 %     897459
```