### PR TITLE
Fixed macCatalyst availability

### DIFF
--- a/Sources/BlurHashViews/MeshGradient+fromBlurHash.swift
+++ b/Sources/BlurHashViews/MeshGradient+fromBlurHash.swift
@@ -20,7 +20,7 @@ public enum BlurHashParsingDetailLevel: Hashable, Codable, Sendable, Equatable {
 	public static let simple: BlurHashParsingDetailLevel = .vertices(width: 2, height: 2)
 }
 
-@available(iOS 18, tvOS 18, visionOS 2, macOS 15, watchOS 11, macCatalyst 13, *)
+@available(iOS 18, tvOS 18, visionOS 2, macOS 15, watchOS 11, macCatalyst 18, *)
 extension MeshGradient {
 	
 	/// Stores the colors and points for creating a `MeshGradient`.

--- a/Sources/BlurHashViews/Previews.swift
+++ b/Sources/BlurHashViews/Previews.swift
@@ -8,7 +8,7 @@
 
 import SwiftUI
 
-@available(iOS 18, tvOS 18, visionOS 2, macOS 15, watchOS 11, macCatalyst 17, *)
+@available(iOS 18, tvOS 18, visionOS 2, macOS 15, watchOS 11, macCatalyst 18, *)
 #Preview {
 	@Previewable @State var punch: Float = 1
 	@Previewable @State var smoothColors: Bool = true

--- a/Sources/BlurHashViews/Previews.swift
+++ b/Sources/BlurHashViews/Previews.swift
@@ -8,7 +8,7 @@
 
 import SwiftUI
 
-@available(iOS 18, tvOS 18, visionOS 2, macOS 15, watchOS 11, macCatalyst 13, *)
+@available(iOS 18, tvOS 18, visionOS 2, macOS 15, watchOS 11, macCatalyst 17, *)
 #Preview {
 	@Previewable @State var punch: Float = 1
 	@Previewable @State var smoothColors: Bool = true


### PR DESCRIPTION
MeshGradient requires macCatalyst 18+, so fixed up the availability checks accordingly.